### PR TITLE
Fix snapshot deletion bug

### DIFF
--- a/aws_manage_snapshots.bash
+++ b/aws_manage_snapshots.bash
@@ -222,7 +222,7 @@ getnumkeep() {
 	getnumkeep=()
 	while read -d $'\n'; do
 		getnumkeep+=("$REPLY")
-  done < <(echo "$listofsnapshots" | awk -v  volume="$vol" 'BEGIN { FS=volume;} {if (NF=="2") print $1 }' )
+  done < <(echo "$listofsnapshots" | awk -v  volume="$vol" 'BEGIN { FS=volume;} {if (NF=="2") print $1 }' | tac )
 
 #actually print which snapshots belong to which volumes
 


### PR DESCRIPTION
The getnumkeep list was sorted to bad direction, the dothedelete function
deleted the latest backup.
